### PR TITLE
suggestion on cast overloads

### DIFF
--- a/include/json/value.h
+++ b/include/json/value.h
@@ -278,9 +278,7 @@ namespace Json {
       operator UInt64() const;
 #endif // if defined(JSON_HAS_INT64)
       LargestInt asLargestInt() const;
-      operator LargestInt() const;
       LargestUInt asLargestUInt() const;
-      operator LargestUInt() const;
       float asFloat() const;
       operator float() const;
       double asDouble() const;

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -266,7 +266,9 @@ namespace Json {
       CppTL::ConstString asConstString() const;
 # endif
       Int asInt() const;
+      operator Int() const;
       UInt asUInt() const;
+      operator UInt() const;
 #if defined(JSON_HAS_INT64)
       Int64 asInt64() const;
       UInt64 asUInt64() const;

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -261,7 +261,9 @@ namespace Json {
       int compare( const Value &other ) const;
 
       const char *asCString() const;
+      operator const char*() const;
       std::string asString() const;
+      operator std::string() const;
 # ifdef JSON_USE_CPPTL
       CppTL::ConstString asConstString() const;
 # endif
@@ -271,13 +273,20 @@ namespace Json {
       operator UInt() const;
 #if defined(JSON_HAS_INT64)
       Int64 asInt64() const;
+      operator Int64() const;
       UInt64 asUInt64() const;
+      operator UInt64() const;
 #endif // if defined(JSON_HAS_INT64)
       LargestInt asLargestInt() const;
+      operator LargestInt() const;
       LargestUInt asLargestUInt() const;
+      operator LargestUInt() const;
       float asFloat() const;
+      operator float() const;
       double asDouble() const;
+      operator double() const;
       bool asBool() const;
+      operator bool() const;
 
       bool isNull() const;
       bool isBool() const;

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -724,6 +724,11 @@ Value::asConstString() const
 }
 # endif
 
+Value::operator 
+Value::Int() const
+{
+    return Value::asInt();
+}
 
 Value::Int 
 Value::asInt() const
@@ -749,6 +754,11 @@ Value::asInt() const
    JSON_FAIL_MESSAGE("Value is not convertible to Int.");
 }
 
+Value::operator 
+Value::UInt() const
+{
+    return Value::asUInt();
+}
 
 Value::UInt 
 Value::asUInt() const

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -686,6 +686,12 @@ Value::operator !=( const Value &other ) const
    return !( *this == other );
 }
 
+Value::operator 
+const char*() const
+{
+    return Value::asCString();
+}
+
 const char *
 Value::asCString() const
 {
@@ -693,6 +699,11 @@ Value::asCString() const
    return value_.string_;
 }
 
+Value::operator 
+std::string() const
+{
+    return Value::asString();
+}
 
 std::string 
 Value::asString() const
@@ -787,6 +798,12 @@ Value::asUInt() const
 
 # if defined(JSON_HAS_INT64)
 
+Value::operator 
+Value::Int64 const
+{
+    return Value::asInt64();
+}
+
 Value::Int64
 Value::asInt64() const
 {
@@ -808,6 +825,12 @@ Value::asInt64() const
       break;
    }
    JSON_FAIL_MESSAGE("Value is not convertible to Int64.");
+}
+
+Value::operator 
+Value::UInt64 const
+{
+    return Value::asUInt64();
 }
 
 
@@ -835,6 +858,11 @@ Value::asUInt64() const
 }
 # endif // if defined(JSON_HAS_INT64)
 
+Value::operator 
+Value::asLargestInt const
+{
+    return Value::asLargestInt();
+}
 
 LargestInt 
 Value::asLargestInt() const
@@ -847,6 +875,12 @@ Value::asLargestInt() const
 }
 
 
+Value::operator 
+Value::asLargestUInt const
+{
+    return Value::asLargestUInt();
+}
+
 LargestUInt 
 Value::asLargestUInt() const
 {
@@ -857,6 +891,11 @@ Value::asLargestUInt() const
 #endif
 }
 
+Value::operator 
+double() const
+{
+    return Value::asDouble();
+}
 
 double 
 Value::asDouble() const
@@ -883,6 +922,12 @@ Value::asDouble() const
    JSON_FAIL_MESSAGE("Value is not convertible to double.");
 }
 
+Value::operator 
+float() const
+{
+    return Value::asFloat();
+}
+
 float
 Value::asFloat() const
 {
@@ -906,6 +951,12 @@ Value::asFloat() const
       break;
    }
    JSON_FAIL_MESSAGE("Value is not convertible to float.");
+}
+
+Value::operator 
+bool() const
+{
+    return Value::asBool();
 }
 
 bool 

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -799,7 +799,7 @@ Value::asUInt() const
 # if defined(JSON_HAS_INT64)
 
 Value::operator 
-Value::Int64 const
+Value::Int64() const
 {
     return Value::asInt64();
 }
@@ -828,7 +828,7 @@ Value::asInt64() const
 }
 
 Value::operator 
-Value::UInt64 const
+Value::UInt64() const
 {
     return Value::asUInt64();
 }
@@ -858,12 +858,6 @@ Value::asUInt64() const
 }
 # endif // if defined(JSON_HAS_INT64)
 
-Value::operator 
-Value::asLargestInt const
-{
-    return Value::asLargestInt();
-}
-
 LargestInt 
 Value::asLargestInt() const
 {
@@ -874,12 +868,6 @@ Value::asLargestInt() const
 #endif
 }
 
-
-Value::operator 
-Value::asLargestUInt const
-{
-    return Value::asLargestUInt();
-}
 
 LargestUInt 
 Value::asLargestUInt() const

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -699,6 +699,7 @@ Value::asCString() const
    return value_.string_;
 }
 
+
 Value::operator 
 std::string() const
 {
@@ -735,6 +736,7 @@ Value::asConstString() const
 }
 # endif
 
+
 Value::operator 
 Value::Int() const
 {
@@ -764,6 +766,7 @@ Value::asInt() const
    }
    JSON_FAIL_MESSAGE("Value is not convertible to Int.");
 }
+
 
 Value::operator 
 Value::UInt() const
@@ -827,12 +830,12 @@ Value::asInt64() const
    JSON_FAIL_MESSAGE("Value is not convertible to Int64.");
 }
 
+
 Value::operator 
 Value::UInt64() const
 {
     return Value::asUInt64();
 }
-
 
 Value::UInt64
 Value::asUInt64() const
@@ -858,6 +861,7 @@ Value::asUInt64() const
 }
 # endif // if defined(JSON_HAS_INT64)
 
+
 LargestInt 
 Value::asLargestInt() const
 {
@@ -878,6 +882,7 @@ Value::asLargestUInt() const
     return asUInt64();
 #endif
 }
+
 
 Value::operator 
 double() const
@@ -910,6 +915,7 @@ Value::asDouble() const
    JSON_FAIL_MESSAGE("Value is not convertible to double.");
 }
 
+
 Value::operator 
 float() const
 {
@@ -940,6 +946,7 @@ Value::asFloat() const
    }
    JSON_FAIL_MESSAGE("Value is not convertible to float.");
 }
+
 
 Value::operator 
 bool() const


### PR DESCRIPTION
Hi, guys.

Nice project.

I'm just curious, can't we overload the type casts so that we don't have to specify `Json::Value::as*()`?

For example, with your current version, we have to specify the type of the values like:

``` cpp
Json::Value json;
int var1 = json["IntParam"].asInt();
std::string var2 = json["StrParam"].asString();
```

However, by applying this pull request, we can do something like:

``` cpp
Json::Value json;
int var1 = json["IntParam"];
std::string var2 = json["StrParam"];
```

_without_ specifying the type, and leave it to the compiler to figure it out from the context.

You may have discussed this prior to transferring to GitHub, but I'd really like to know why you're adapting explicit type specifications without using the features of C++.

Thanks in advance :)
